### PR TITLE
Need to specify relative or absolute path to the volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ candidate:
   ports:
     - "9881:8080"
   volumes:
-    - flavors/candidate:/root/.rest_shifter/flavors
+    - $PWD/flavors/candidate:/root/.rest_shifter/flavors
   command: -s
 
 primary:
@@ -22,7 +22,7 @@ primary:
   ports:
     - "9882:8080"
   volumes:
-    - flavors/primary:/root/.rest_shifter/flavors
+    - $PWD/flavors/primary:/root/.rest_shifter/flavors
   command: -s
 
 secondary:
@@ -30,5 +30,5 @@ secondary:
   ports:
     - "9883:8080"
   volumes:
-    - flavors/secondary:/root/.rest_shifter/flavors
+    - $PWD/flavors/secondary:/root/.rest_shifter/flavors
   command: -s


### PR DESCRIPTION
If we don't add $PWD/ or ./, then it complains:
ERROR: for candidate  Cannot create container for service candidate: create flavors/candidate: "flavors/candidate" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed
ERROR: Encountered errors while bringing up the project.